### PR TITLE
Allow workflow updates on Renovate branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,9 @@
     "config:recommended"
   ],
   "automerge": true,
+  "gitIgnoredAuthors": [
+    "41898282+github-actions[bot]@users.noreply.github.com"
+  ],
   "postUpdateOptions": ["gomodTidy"],
   "nix": {
     "enabled": true


### PR DESCRIPTION
Otherwise PRs like https://github.com/scip-code/scip-go/pull/289 won't be automatically mergd.